### PR TITLE
Add regression tests for previously fixed internal errors

### DIFF
--- a/typed-racket-test/fail/gh-issue-1028.rkt
+++ b/typed-racket-test/fail/gh-issue-1028.rkt
@@ -1,0 +1,9 @@
+#;
+(exn-pred #rx"expected single value, got multiple")
+#lang typed/racket
+
+;; Issue #1028: Incorrect with-handlers usage previously caused an internal
+;; typechecker error "get-range-result: should not happen". Fixed to give
+;; a proper type error about expecting single value.
+
+(with-handlers ([exn:fail? (values #f #f)]) (values #t #t))

--- a/typed-racket-test/fail/gh-issue-1268.rkt
+++ b/typed-racket-test/fail/gh-issue-1268.rkt
@@ -1,0 +1,11 @@
+#;
+(exn-pred #rx"Inference for polymorphic keyword functions not supported")
+#lang typed/racket
+
+;; Issue #1268: hash-union with #:combine previously caused an internal
+;; match-define error. Fixed to give a proper type error about polymorphic
+;; keyword function inference.
+
+(require racket/hash)
+
+(hash-union (make-hash) (make-hash) #:combine (lambda (a b) a))

--- a/typed-racket-test/fail/gh-issue-368.rkt
+++ b/typed-racket-test/fail/gh-issue-368.rkt
@@ -1,0 +1,8 @@
+#;
+(exn-pred #rx"broke its own contract")
+#lang typed/racket
+
+;; Issue #368: cast with wrong type previously threw an internal error
+;; "procedure-arity: contract violation" instead of a proper contract failure.
+
+(cast 3 (-> Integer Integer))

--- a/typed-racket-test/fail/gh-issue-425.rkt
+++ b/typed-racket-test/fail/gh-issue-425.rkt
@@ -1,0 +1,9 @@
+#;
+(exn-pred #rx"cannot apply a non-polymorphic type")
+#lang typed/racket
+
+;; Issue #425: Regression test - previously caused internal error
+;; "Base type L+ not in predefined-type-table" when using recursive
+;; type definitions with intersection types incorrectly.
+
+(define-type (L+ T REST) (Pairof T (∩ (L+ T Any) REST)))

--- a/typed-racket-test/fail/gh-issue-658.rkt
+++ b/typed-racket-test/fail/gh-issue-658.rkt
@@ -1,0 +1,16 @@
+#;
+(exn-pred #rx"cannot apply a non-polymorphic type")
+#lang typed/racket
+
+;; Issue #658: Invalid *-> type previously caused an internal error
+;; "erroneous syntax was not a syntax object". Fixed to give a proper
+;; type error about applying a non-polymorphic type.
+
+(struct Node [{reachable : Edge}])
+(struct Edge [{to : Symbol} {cost : Positive-Integer}])
+
+(define-type Graph [Immutable-HashTable Symbol Node])
+
+(: make-graph (Node *-> Graph))
+(define (make-graph . lo-node)
+  (make-immutable-hash))

--- a/typed-racket-test/succeed/gh-issue-1144.rkt
+++ b/typed-racket-test/succeed/gh-issue-1144.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket
+
+;; Issue #1144: Referencing certain identifiers like exn:srclocs? previously
+;; caused an internal "syntax-property: contract violation" error.
+;; Now properly returns the procedure.
+
+(ann exn:srclocs? (-> Any Boolean))
+(ann rename-transformer? (-> Any Boolean))
+(ann set!-transformer? (-> Any Boolean))

--- a/typed-racket-test/succeed/gh-issue-229.rkt
+++ b/typed-racket-test/succeed/gh-issue-229.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket
+
+;; Issue #229: Typed units with signatures from submodules previously
+;; caused a "free-id-table-ref: contract violation" internal error.
+;; Now type checks correctly.
+
+(module a typed/racket
+  (provide foo^)
+
+  (define-signature foo^
+    ([some-class% : ClassTop])))
+
+(require 'a)
+
+(define-unit foo@
+  (import)
+  (export foo^)
+
+  (define some-class%
+    (class object%
+      (super-new))))

--- a/typed-racket-test/succeed/gh-issue-318.rkt
+++ b/typed-racket-test/succeed/gh-issue-318.rkt
@@ -1,0 +1,17 @@
+#lang typed/racket
+
+;; Issue #318: Regression test - previously caused internal error when overriding
+;; a method that returns multiple values including 'this'.
+;; This was fixed in an earlier version of Typed Racket.
+
+(define atree%
+  (class object%
+    (super-new)
+    (define/public (m)
+      (values #f this))))
+
+(define state%
+  (class atree%
+    (super-new)
+    (define/override (m)
+      (values #f this))))

--- a/typed-racket-test/succeed/gh-issue-378.rkt
+++ b/typed-racket-test/succeed/gh-issue-378.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket
+
+;; Issue #378: cast in dead code previously caused an internal error
+;; "contract-def-property: thunk called too early". Now works correctly.
+
+(define result
+  (cond [#false (cast 1 Integer)]
+        [else 2]))
+
+(unless (= result 2)
+  (error "expected 2"))

--- a/typed-racket-test/succeed/gh-issue-82.rkt
+++ b/typed-racket-test/succeed/gh-issue-82.rkt
@@ -1,0 +1,10 @@
+#lang typed/racket
+
+;; Issue #82: Previously caused internal error "Tried to move vars to
+;; dbound that already exists" when using plambda with dotted type
+;; variables. Now type checks correctly.
+
+(: f (-> One (List One String Char) : #:object (0 0)))
+(define (f [x : One])
+  (let ([f (plambda: (a ...) [w : a ... a] w)])
+    (f x "hello" #\c)))


### PR DESCRIPTION
## Summary
Adds regression tests for internal error issues that were fixed in previous versions:
- #82: plambda with dotted type variables
- #229: Typed units with signatures from submodules
- #318: Overriding method in typed class
- #368: cast with wrong type gives contract failure
- #378: cast in dead code
- #425: Recursive type with intersection
- #658: Invalid *-> type
- #1028: with-handlers with multiple values
- #1144: exn:srclocs? and similar identifiers
- #1268: hash-union with #:combine

## Test plan
- [x] All tests pass with `racket -l typed-racket-test -- --just <test>`
- [ ] Full CI test suite